### PR TITLE
Bump up to 0.2.3

### DIFF
--- a/main.go
+++ b/main.go
@@ -36,7 +36,7 @@ import (
 var (
 	// these will be set by the goreleaser configuration
 	// to appropriate values for the compiled binary.
-	version string = "0.2.2"
+	version string = "0.2.3"
 
 	// goreleaser can pass other information to the main package, such as the specific commit
 	// https://goreleaser.com/cookbooks/using-main.version/


### PR DESCRIPTION
Releasing 0.2.2 was failed. So, we are trying to release 0.2.3.