### PR TITLE
Configure PR Agent to use Gemini Pro model

### DIFF
--- a/.pr_agent.toml
+++ b/.pr_agent.toml
@@ -1,6 +1,7 @@
 # https://pr-agent-docs.codium.ai/
 # https://github.com/Codium-ai/pr-agent/blob/main/pr_agent/settings/configuration.toml
 
+
 [config]
 ignore_pr_labels = ['renovate']
 # models


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- This PR configures the PR Agent to use the `vertex_ai/gemini-1.5-pro` model.
- It also adds an empty line to the beginning of the `.pr_agent.toml` file.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>.pr_agent.toml</strong><dd><code>Configure PR Agent to use Gemini Pro model</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.pr_agent.toml

<li>An empty line was added to the beginning of the file.<br> <li> The <code>model</code> is set to <code>vertex_ai/gemini-1.5-pro</code>.


</details>


  </td>
  <td><a href="https://github.com/ubie-oss/terraform-provider-lightdash/pull/191/files#diff-356a4c0b1558da9e4be849aa64f19af78488ec6819f379e21ae93c53e750fbe7">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information