### PR TITLE
Enhance: Add new test cases and update pre-commit hooks


### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -26,7 +26,6 @@ linters:
     - predeclared
     - unconvert
     - unparam
-    - usetesting
   exclusions:
     presets:
       - comments

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,7 +14,7 @@
 
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.5.0
+    rev: v5.0.0
     hooks:
       - id: end-of-file-fixer
       - id: trailing-whitespace
@@ -22,11 +22,11 @@ repos:
       - id: check-yaml
       - id: detect-private-key
   - repo: https://github.com/rhysd/actionlint
-    rev: v1.6.27
+    rev: v1.7.7
     hooks:
       - id: actionlint-docker
   - repo: https://github.com/adrienverge/yamllint.git
-    rev: v1.35.1
+    rev: v1.37.1
     hooks:
       - id: yamllint
         args: [--strict, -c=.yamllint.yaml]
@@ -48,7 +48,7 @@ repos:
       # - id: go-critic
       - id: go-mod-tidy
   - repo: https://github.com/golangci/golangci-lint
-    rev: v1.57.2
+    rev: v2.1.6
     hooks:
       - id: golangci-lint
   # Run `go generate ./...` local
@@ -56,11 +56,11 @@ repos:
     hooks:
       - id: go-generate
         name: go generate
-        entry: go
-        args: [generate, ./...]
+        entry: bash
+        args: [-c, go generate ./...]
         language: system
         types: [go]
   - repo: https://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.88.4
+    rev: v1.99.0
     hooks:
       - id: terraform_fmt


### PR DESCRIPTION
### **PR Type**
Tests, Enhancement


___

### **Description**
- Adds new test cases for `lightdash_space` resource:
  - `TestAccSpaceResource_nested` for nested spaces.
  - `TestAccSpaceResource_access` for space access.
  - `TestAccSpaceResource_import` for importing spaces.

- Updates pre-commit hooks and linters:
  - Updates `pre-commit-hooks` to `v5.0.0`.
  - Updates `actionlint` to `v1.7.7`.
  - Updates `yamllint` to `v1.37.1`.
  - Updates `golangci-lint` to `v2.1.6`.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>resource_lightdash_space_test.go</strong><dd><code>Add new test cases for space resource</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal/provider/resource_lightdash_space_test.go

<li>Added <code>TestAccSpaceResource_nested</code> to test nested spaces.<br> <li> Added <code>TestAccSpaceResource_access</code> to test space access.<br> <li> Added <code>TestAccSpaceResource_import</code> to test space import functionality.<br> <li> Refactored existing test to <code>TestAccSpaceResource_simple</code>.


</details>


  </td>
  <td><a href="https://github.com/ubie-oss/terraform-provider-lightdash/pull/264/files#diff-660b69185033d8c5d1ee828b2802a86f2d26f8ae1e3446dda757a4f1a9cab7fd">+130/-1</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>.golangci.yml</strong><dd><code>Remove `usetesting` linter</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.golangci.yml

- Removed `usetesting` from the enabled linters.


</details>


  </td>
  <td><a href="https://github.com/ubie-oss/terraform-provider-lightdash/pull/264/files#diff-6179837f7df53a6f05c522b6b7bb566d484d5465d9894fb04910dd08bb40dcc9">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Dependencies</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>.pre-commit-config.yaml</strong><dd><code>Update pre-commit hook versions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.pre-commit-config.yaml

<li>Updated <code>pre-commit-hooks</code> to <code>v5.0.0</code>.<br> <li> Updated <code>actionlint</code> to <code>v1.7.7</code>.<br> <li> Updated <code>yamllint</code> to <code>v1.37.1</code>.<br> <li> Updated <code>golangci-lint</code> to <code>v2.1.6</code>.


</details>


  </td>
  <td><a href="https://github.com/ubie-oss/terraform-provider-lightdash/pull/264/files#diff-63a9c44a44acf85fea213a857769990937107cf072831e1a26808cfde9d096b9">+7/-7</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>