### PR TITLE
Add ACC tests for `lightdash_project_role_group` resource


### DIFF
--- a/internal/provider/acc_tests/resource_lightdash_project_role_group/grant/010_grant.tf
+++ b/internal/provider/acc_tests/resource_lightdash_project_role_group/grant/010_grant.tf
@@ -1,0 +1,13 @@
+data "lightdash_organization" "test" {
+}
+
+resource "lightdash_group" "test_group" {
+  organization_uuid = data.lightdash_organization.test.organization_uuid
+  name              = "test-grant-project-role-group (Acceptance Test)"
+}
+
+resource "lightdash_project_role_group" "test_project_role_group" {
+  project_uuid = data.lightdash_project.test.project_uuid
+  group_uuid   = lightdash_group.test_group.group_uuid
+  role         = "viewer"
+}

--- a/internal/provider/acc_tests/resource_lightdash_project_role_group/grant/020_grant.tf
+++ b/internal/provider/acc_tests/resource_lightdash_project_role_group/grant/020_grant.tf
@@ -1,0 +1,13 @@
+data "lightdash_organization" "test" {
+}
+
+resource "lightdash_group" "test_group" {
+  organization_uuid = data.lightdash_organization.test.organization_uuid
+  name              = "test-grant-project-role-group (Acceptance Test)"
+}
+
+resource "lightdash_project_role_group" "test_project_role_group" {
+  project_uuid = data.lightdash_project.test.project_uuid
+  group_uuid   = lightdash_group.test_group.group_uuid
+  role         = "interactive_viewer"
+}

--- a/internal/provider/acc_tests/resource_lightdash_project_role_group/grant/030_grant.tf
+++ b/internal/provider/acc_tests/resource_lightdash_project_role_group/grant/030_grant.tf
@@ -1,0 +1,13 @@
+data "lightdash_organization" "test" {
+}
+
+resource "lightdash_group" "test_group" {
+  organization_uuid = data.lightdash_organization.test.organization_uuid
+  name              = "test-grant-project-role-group (Acceptance Test)"
+}
+
+resource "lightdash_project_role_group" "test_project_role_group" {
+  project_uuid = data.lightdash_project.test.project_uuid
+  group_uuid   = lightdash_group.test_group.group_uuid
+  role         = "editor"
+}

--- a/internal/provider/acc_tests/resource_lightdash_project_role_group/grant/040_grant.tf
+++ b/internal/provider/acc_tests/resource_lightdash_project_role_group/grant/040_grant.tf
@@ -1,0 +1,13 @@
+data "lightdash_organization" "test" {
+}
+
+resource "lightdash_group" "test_group" {
+  organization_uuid = data.lightdash_organization.test.organization_uuid
+  name              = "test-grant-project-role-group (Acceptance Test)"
+}
+
+resource "lightdash_project_role_group" "test_project_role_group" {
+  project_uuid = data.lightdash_project.test.project_uuid
+  group_uuid   = lightdash_group.test_group.group_uuid
+  role         = "developer"
+}

--- a/internal/provider/acc_tests/resource_lightdash_project_role_group/grant/050_grant.tf
+++ b/internal/provider/acc_tests/resource_lightdash_project_role_group/grant/050_grant.tf
@@ -1,0 +1,13 @@
+data "lightdash_organization" "test" {
+}
+
+resource "lightdash_group" "test_group" {
+  organization_uuid = data.lightdash_organization.test.organization_uuid
+  name              = "test-grant-project-role-group (Acceptance Test)"
+}
+
+resource "lightdash_project_role_group" "test_project_role_group" {
+  project_uuid = data.lightdash_project.test.project_uuid
+  group_uuid   = lightdash_group.test_group.group_uuid
+  role         = "admin"
+}

--- a/internal/provider/acc_tests/resource_lightdash_project_role_group/import/010_grant.tf
+++ b/internal/provider/acc_tests/resource_lightdash_project_role_group/import/010_grant.tf
@@ -1,0 +1,13 @@
+data "lightdash_organization" "test" {
+}
+
+resource "lightdash_group" "test_group" {
+  organization_uuid = data.lightdash_organization.test.organization_uuid
+  name              = "test-grant-project-role-group (Acceptance Test)"
+}
+
+resource "lightdash_project_role_group" "test_project_role_group" {
+  project_uuid = data.lightdash_project.test.project_uuid
+  group_uuid   = lightdash_group.test_group.group_uuid
+  role         = "viewer"
+}

--- a/internal/provider/acc_tests/resource_lightdash_project_role_group/import/010_import.tf
+++ b/internal/provider/acc_tests/resource_lightdash_project_role_group/import/010_import.tf
@@ -3,7 +3,7 @@ data "lightdash_organization" "test" {
 
 resource "lightdash_group" "test_group" {
   organization_uuid = data.lightdash_organization.test.organization_uuid
-  name              = "test-grant-project-role-group (Acceptance Test)"
+  name              = "test-grant-project-role-group (Acceptance Test - import)"
 }
 
 resource "lightdash_project_role_group" "test_project_role_group" {

--- a/internal/provider/resource_lightdash_project_role_group.go
+++ b/internal/provider/resource_lightdash_project_role_group.go
@@ -312,8 +312,9 @@ func (r *projectRoleGroupResource) ImportState(ctx context.Context, req resource
 	}
 
 	// Set the resource attributes
-	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("project_uuid"), group.ProjectUUID)...)
-	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("group_uuid"), group.GroupUUID)...)
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("id"), req.ID)...)
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("project_uuid"), project_uuid)...)
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("group_uuid"), group_uuid)...)
 	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("role"), group.ProjectRole)...)
 }
 

--- a/internal/provider/resource_lightdash_project_role_group_test.go
+++ b/internal/provider/resource_lightdash_project_role_group_test.go
@@ -15,9 +15,11 @@
 package provider
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
 )
 
 // Using the shared testAccPreCheck and testAccProtoV6ProviderFactories from provider_acc_test.go
@@ -100,6 +102,73 @@ func TestAccProjectRoleGroupResource_grant(t *testing.T) {
 					// lightdash_project_role_group.resource_lightdash_project_role_group__grant
 					resource.TestCheckResourceAttr("lightdash_project_role_group.test_project_role_group", "role", "admin"),
 				),
+			},
+		},
+	})
+}
+
+func TestAccProjectRoleGroupResource_import(t *testing.T) {
+	if !isIntegrationTestMode() {
+		t.Skip("Skipping acceptance test for resource_lightdash_project_role_group")
+	}
+
+	// Get the provider config
+	providerConfig, err := getProviderConfig()
+	if err != nil {
+		t.Fatalf("Failed to get providerConfig: %v", err)
+	}
+
+	// Test of simple space creation
+	importConfig010, err := ReadAccTestResource([]string{"resource_lightdash_project_role_group", "import", "010_import.tf"})
+	if err != nil {
+		t.Fatalf("Failed to get publicSpaceConfig: %v", err)
+	}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: providerConfig + importConfig010,
+				Check: resource.ComposeTestCheckFunc(
+					// lightdash_project_role_group.resource_lightdash_project_role_group__grant
+					resource.TestCheckResourceAttrSet("lightdash_project_role_group.test_project_role_group", "project_uuid"),
+					resource.TestCheckResourceAttr("lightdash_project_role_group.test_project_role_group", "role", "viewer"),
+					resource.TestCheckResourceAttrPair(
+						"lightdash_project_role_group.test_project_role_group",
+						"group_uuid",
+						"lightdash_group.test_group",
+						"group_uuid",
+					),
+				),
+			},
+			{
+				Config:            providerConfig + importConfig010,
+				ResourceName:      "lightdash_project_role_group.test_project_role_group",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"last_updated",
+				},
+				ImportStateIdFunc: func(state *terraform.State) (string, error) {
+					res, ok := state.RootModule().Resources["lightdash_project_role_group.test_project_role_group"]
+					if !ok {
+						return "", fmt.Errorf("resource not found in state for import")
+					}
+					// Get the project_uuid from the state
+					project_uuid, ok := res.Primary.Attributes["project_uuid"]
+					if !ok && project_uuid != "" {
+						return "", fmt.Errorf("project_uuid attribute not present in state")
+					}
+					// Get the group_uuid from the state
+					group_uuid, ok := res.Primary.Attributes["group_uuid"]
+					if !ok && group_uuid != "" {
+						return "", fmt.Errorf("group_uuid attribute not present in state")
+					}
+					// Construct the import ID in the form 'projects/<project_uuid>/access-groups/<group_uuid>'
+					id := getProjectRoleGroupResourceId(project_uuid, group_uuid)
+					return id, nil
+				},
 			},
 		},
 	})

--- a/internal/provider/resource_lightdash_project_role_group_test.go
+++ b/internal/provider/resource_lightdash_project_role_group_test.go
@@ -1,0 +1,106 @@
+// Copyright 2023 Ubie, inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package provider
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+// Using the shared testAccPreCheck and testAccProtoV6ProviderFactories from provider_acc_test.go
+
+func TestAccProjectRoleGroupResource_grant(t *testing.T) {
+	if !isIntegrationTestMode() {
+		t.Skip("Skipping acceptance test for resource_lightdash_project_role_group")
+	}
+
+	// Get the provider config
+	providerConfig, err := getProviderConfig()
+	if err != nil {
+		t.Fatalf("Failed to get providerConfig: %v", err)
+	}
+
+	// Test of simple space creation
+	grantConfig010, err := ReadAccTestResource([]string{"resource_lightdash_project_role_group", "grant", "010_grant.tf"})
+	if err != nil {
+		t.Fatalf("Failed to get publicSpaceConfig: %v", err)
+	}
+	grantConfig020, err := ReadAccTestResource([]string{"resource_lightdash_project_role_group", "grant", "020_grant.tf"})
+	if err != nil {
+		t.Fatalf("Failed to get publicSpaceConfig: %v", err)
+	}
+	grantConfig030, err := ReadAccTestResource([]string{"resource_lightdash_project_role_group", "grant", "030_grant.tf"})
+	if err != nil {
+		t.Fatalf("Failed to get publicSpaceConfig: %v", err)
+	}
+	grantConfig040, err := ReadAccTestResource([]string{"resource_lightdash_project_role_group", "grant", "040_grant.tf"})
+	if err != nil {
+		t.Fatalf("Failed to get publicSpaceConfig: %v", err)
+	}
+	grantConfig050, err := ReadAccTestResource([]string{"resource_lightdash_project_role_group", "grant", "050_grant.tf"})
+	if err != nil {
+		t.Fatalf("Failed to get publicSpaceConfig: %v", err)
+	}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: providerConfig + grantConfig010,
+				Check: resource.ComposeTestCheckFunc(
+					// lightdash_project_role_group.resource_lightdash_project_role_group__grant
+					resource.TestCheckResourceAttrSet("lightdash_project_role_group.test_project_role_group", "project_uuid"),
+					resource.TestCheckResourceAttr("lightdash_project_role_group.test_project_role_group", "role", "viewer"),
+					resource.TestCheckResourceAttrPair(
+						"lightdash_project_role_group.test_project_role_group",
+						"group_uuid",
+						"lightdash_group.test_group",
+						"group_uuid",
+					),
+				),
+			},
+			{
+				Config: providerConfig + grantConfig020,
+				Check: resource.ComposeTestCheckFunc(
+					// lightdash_project_role_group.resource_lightdash_project_role_group__grant
+					resource.TestCheckResourceAttr("lightdash_project_role_group.test_project_role_group", "role", "interactive_viewer"),
+				),
+			},
+			{
+				Config: providerConfig + grantConfig030,
+				Check: resource.ComposeTestCheckFunc(
+					// lightdash_project_role_group.resource_lightdash_project_role_group__grant
+					resource.TestCheckResourceAttr("lightdash_project_role_group.test_project_role_group", "role", "editor"),
+				),
+			},
+			{
+				Config: providerConfig + grantConfig040,
+				Check: resource.ComposeTestCheckFunc(
+					// lightdash_project_role_group.resource_lightdash_project_role_group__grant
+					resource.TestCheckResourceAttr("lightdash_project_role_group.test_project_role_group", "role", "developer"),
+				),
+			},
+			{
+				Config: providerConfig + grantConfig050,
+				Check: resource.ComposeTestCheckFunc(
+					// lightdash_project_role_group.resource_lightdash_project_role_group__grant
+					resource.TestCheckResourceAttr("lightdash_project_role_group.test_project_role_group", "role", "admin"),
+				),
+			},
+		},
+	})
+}


### PR DESCRIPTION
### **PR Type**
Tests


___

### **Description**
- Add acceptance tests for `lightdash_project_role_group`.

- Test granting different roles: viewer, interactive_viewer, editor, developer, admin.

- Implement import state verification for the resource.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>resource_lightdash_project_role_group.go</strong><dd><code>Fix `ImportState` function for `project_role_group`</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/ubie-oss/terraform-provider-lightdash/pull/266/files#diff-49430849697608110d5ff5967f20ebd24a386106b1671c667dfa2f097c635a10">+3/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>7 files</summary><table>
<tr>
  <td><strong>resource_lightdash_project_role_group_test.go</strong><dd><code>Implement acceptance tests for `lightdash_project_role_group`</code></dd></td>
  <td><a href="https://github.com/ubie-oss/terraform-provider-lightdash/pull/266/files#diff-1e258eb6fbe27289bbcfa93d389d00a50ccc1356b1ed5d0fd3066064619a1ccc">+175/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>010_grant.tf</strong><dd><code>Add test config for granting viewer role</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/ubie-oss/terraform-provider-lightdash/pull/266/files#diff-61685f545611e69f49b93164a7c5917455ec2bb9ec93ad5d163092fd50889747">+13/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>020_grant.tf</strong><dd><code>Add test config for granting interactive_viewer role</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/ubie-oss/terraform-provider-lightdash/pull/266/files#diff-be9c67085efb7f3dd0df0e3724211837bf433bb814a9583bbb017b707cb07cbf">+13/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>030_grant.tf</strong><dd><code>Add test config for granting editor role</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/ubie-oss/terraform-provider-lightdash/pull/266/files#diff-50c79cabebcf3b8a049fc1d9ba4e5fdb019b3268fc81fa133db548997056a57b">+13/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>040_grant.tf</strong><dd><code>Add test config for granting developer role</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/ubie-oss/terraform-provider-lightdash/pull/266/files#diff-d3ea5d2d5bcdfae717027806266aefbf9168018bff89ca68cce85929e46c5366">+13/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>050_grant.tf</strong><dd><code>Add test config for granting admin role</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/ubie-oss/terraform-provider-lightdash/pull/266/files#diff-f1fd3db841da5924b282d9b77bc71175278853eb9a4c81fb0b1dddeac08351f0">+13/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>010_import.tf</strong><dd><code>Add test config for importing `project_role_group`</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/ubie-oss/terraform-provider-lightdash/pull/266/files#diff-b50f81e678e08428be118e6bf958d1479f37e6631a6632c4b7bf82b13d20f7b2">+13/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>