### PR TITLE
Fix: Correct `lightdash_group` Import State ID and Add Acceptance Tests


### DIFF
--- a/internal/provider/acc_tests/resource_lightdash_group/create/010_create.tf
+++ b/internal/provider/acc_tests/resource_lightdash_group/create/010_create.tf
@@ -1,0 +1,8 @@
+data "lightdash_organization" "test" {
+}
+
+resource "lightdash_group" "test_group" {
+  organization_uuid = data.lightdash_organization.test.organization_uuid
+  name              = "test (Acceptance Test - create)"
+  members           = []
+}

--- a/internal/provider/acc_tests/resource_lightdash_group/import/010_import.tf
+++ b/internal/provider/acc_tests/resource_lightdash_group/import/010_import.tf
@@ -1,0 +1,8 @@
+data "lightdash_organization" "test" {
+}
+
+resource "lightdash_group" "test_group" {
+  organization_uuid = data.lightdash_organization.test.organization_uuid
+  name              = "test (Acceptance Test - import)"
+  members           = []
+}

--- a/internal/provider/resource_lightdash_group.go
+++ b/internal/provider/resource_lightdash_group.go
@@ -412,7 +412,7 @@ func (r *groupResource) ImportState(ctx context.Context, req resource.ImportStat
 	}
 
 	// Set the resource attributes
-	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("id"), groupUuid)...)
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("id"), req.ID)...)
 	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("organization_uuid"), importedGroup.OrganizationUUID)...)
 	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("group_uuid"), importedGroup.GroupUUID)...)
 	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("name"), importedGroup.Name)...)

--- a/internal/provider/resource_lightdash_group_test.go
+++ b/internal/provider/resource_lightdash_group_test.go
@@ -1,0 +1,117 @@
+// Copyright 2023 Ubie, inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package provider
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+)
+
+// Using the shared testAccPreCheck and testAccProtoV6ProviderFactories from provider_acc_test.go
+
+func TestAccGroupResource_grant(t *testing.T) {
+	if !isIntegrationTestMode() {
+		t.Skip("Skipping acceptance test for resource_lightdash_group")
+	}
+
+	// Get the provider config
+	providerConfig, err := getProviderConfig()
+	if err != nil {
+		t.Fatalf("Failed to get providerConfig: %v", err)
+	}
+
+	// Test of simple space creation
+	createConfig010, err := ReadAccTestResource([]string{"resource_lightdash_group", "create", "010_create.tf"})
+	if err != nil {
+		t.Fatalf("Failed to get createConfig: %v", err)
+	}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: providerConfig + createConfig010,
+				Check: resource.ComposeTestCheckFunc(
+					// lightdash_group.test_group
+					resource.TestCheckResourceAttr("lightdash_group.test_group", "name", "test (Acceptance Test - create)"),
+					resource.TestCheckResourceAttr("lightdash_group.test_group", "members.#", "0"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccGroupResource_import(t *testing.T) {
+	if !isIntegrationTestMode() {
+		t.Skip("Skipping acceptance test for resource_lightdash_group")
+	}
+
+	// Get the provider config
+	providerConfig, err := getProviderConfig()
+	if err != nil {
+		t.Fatalf("Failed to get providerConfig: %v", err)
+	}
+
+	// Test of simple space creation
+	importConfig010, err := ReadAccTestResource([]string{"resource_lightdash_group", "import", "010_import.tf"})
+	if err != nil {
+		t.Fatalf("Failed to get importConfig: %v", err)
+	}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: providerConfig + importConfig010,
+				Check: resource.ComposeTestCheckFunc(
+					// lightdash_group.test_group
+					resource.TestCheckResourceAttr("lightdash_group.test_group", "name", "test (Acceptance Test - import)"),
+					resource.TestCheckResourceAttr("lightdash_group.test_group", "members.#", "0"),
+				),
+			},
+			{
+				Config:                  providerConfig + importConfig010,
+				ResourceName:            "lightdash_group.test_group",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{},
+				ImportStateIdFunc: func(state *terraform.State) (string, error) {
+					res, ok := state.RootModule().Resources["lightdash_group.test_group"]
+					if !ok {
+						return "", fmt.Errorf("resource not found in state for import")
+					}
+					// Get the organization_uuid from the state
+					organization_uuid, ok := res.Primary.Attributes["organization_uuid"]
+					if !ok || organization_uuid == "" {
+						return "", fmt.Errorf("organization_uuid attribute not present in state")
+					}
+					// Get the group_uuid from the state
+					group_uuid, ok := res.Primary.Attributes["group_uuid"]
+					if !ok || group_uuid == "" {
+						return "", fmt.Errorf("group_uuid attribute not present in state")
+					}
+					// Construct the import ID in the form 'organizations/<organization_uuid>/groups/<group_uuid>'
+					id := getGroupResourceId(organization_uuid, group_uuid)
+					return id, nil
+				},
+			},
+		},
+	})
+}

--- a/internal/provider/resource_lightdash_project_role_group_test.go
+++ b/internal/provider/resource_lightdash_project_role_group_test.go
@@ -157,12 +157,12 @@ func TestAccProjectRoleGroupResource_import(t *testing.T) {
 					}
 					// Get the project_uuid from the state
 					project_uuid, ok := res.Primary.Attributes["project_uuid"]
-					if !ok && project_uuid != "" {
+					if !ok || project_uuid == "" {
 						return "", fmt.Errorf("project_uuid attribute not present in state")
 					}
 					// Get the group_uuid from the state
 					group_uuid, ok := res.Primary.Attributes["group_uuid"]
-					if !ok && group_uuid != "" {
+					if !ok || group_uuid == "" {
 						return "", fmt.Errorf("group_uuid attribute not present in state")
 					}
 					// Construct the import ID in the form 'projects/<project_uuid>/access-groups/<group_uuid>'

--- a/internal/provider/resource_lightdash_space_test.go
+++ b/internal/provider/resource_lightdash_space_test.go
@@ -335,12 +335,12 @@ func TestAccSpaceResource_import(t *testing.T) {
 					}
 					// Get the project_uuid from the state
 					project_uuid, ok := res.Primary.Attributes["project_uuid"]
-					if !ok {
+					if !ok || project_uuid == "" {
 						return "", fmt.Errorf("project_uuid attribute not present in state")
 					}
 					// Get the space_uuid from the state
 					space_uuid, ok := res.Primary.Attributes["space_uuid"]
-					if !ok {
+					if !ok || space_uuid == "" {
 						return "", fmt.Errorf("space_uuid attribute not present in state")
 					}
 					// Construct the import ID in the form 'projects/<project_uuid>/spaces/<space_uuid>'


### PR DESCRIPTION
### **PR Type**
Enhancement, Tests


___

### **Description**
- Fixes `lightdash_group` import state ID.

- Adds acceptance tests for `lightdash_group` resource.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>resource_lightdash_group.go</strong><dd><code>Fix import state ID for `lightdash_group`</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal/provider/resource_lightdash_group.go

<li>Fixes the import state function to correctly set the <code>id</code> attribute.<br> <li> The <code>id</code> is now set to <code>req.ID</code> instead of <code>groupUuid</code>.


</details>


  </td>
  <td><a href="https://github.com/ubie-oss/terraform-provider-lightdash/pull/268/files#diff-5cf72a621e6d6492a0c4c6617ee4ba297a73853f2fcea51caef7de1e7d87a899">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>resource_lightdash_project_role_group_test.go</strong><dd><code>Fix: Correct conditions for checking UUIDs in import test</code></dd></summary>
<hr>

internal/provider/resource_lightdash_project_role_group_test.go

<li>Fixes a bug in <code>TestAccProjectRoleGroupResource_import</code> where the <br>conditions for checking <code>project_uuid</code> and <code>group_uuid</code> were incorrect.<br> <li> The conditions <code>!ok && project_uuid != ""</code> and <code>!ok && group_uuid != ""</code> <br>are changed to <code>!ok || project_uuid == ""</code> and <code>!ok || group_uuid == ""</code>, <br>respectively.


</details>


  </td>
  <td><a href="https://github.com/ubie-oss/terraform-provider-lightdash/pull/268/files#diff-1e258eb6fbe27289bbcfa93d389d00a50ccc1356b1ed5d0fd3066064619a1ccc">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>resource_lightdash_space_test.go</strong><dd><code>Fix: Correct conditions for checking UUIDs in import test</code></dd></summary>
<hr>

internal/provider/resource_lightdash_space_test.go

<li>Fixes a bug in <code>TestAccSpaceResource_import</code> where the conditions for <br>checking <code>project_uuid</code> and <code>space_uuid</code> were incorrect.<br> <li> The conditions <code>!ok</code> is changed to <code>!ok || project_uuid == ""</code> and <code>!ok || </code><br><code>space_uuid == ""</code>, respectively.


</details>


  </td>
  <td><a href="https://github.com/ubie-oss/terraform-provider-lightdash/pull/268/files#diff-660b69185033d8c5d1ee828b2802a86f2d26f8ae1e3446dda757a4f1a9cab7fd">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>resource_lightdash_group_test.go</strong><dd><code>Add acceptance tests for `lightdash_group` resource</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal/provider/resource_lightdash_group_test.go

<li>Adds acceptance tests for the <code>lightdash_group</code> resource.<br> <li> Includes tests for basic creation and import functionality.<br> <li> Uses <code>ReadAccTestResource</code> to read test configurations from files.


</details>


  </td>
  <td><a href="https://github.com/ubie-oss/terraform-provider-lightdash/pull/268/files#diff-867a4ffab6665f9cbf4bfcca8cd5d3e6cef7abbb55b936d04d659a0fcfeded41">+117/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>010_create.tf</strong><dd><code>Add test configuration for creating `lightdash_group`</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal/provider/acc_tests/resource_lightdash_group/create/010_create.tf

<li>Adds a test configuration file for creating a <code>lightdash_group</code> <br>resource.<br> <li> Defines a <code>lightdash_group</code> resource named <code>test_group</code> with a specified <br><code>organization_uuid</code>, <code>name</code>, and empty <code>members</code>.


</details>


  </td>
  <td><a href="https://github.com/ubie-oss/terraform-provider-lightdash/pull/268/files#diff-081559e3456377af9c0c78fb33ad55000c4dbb013a5308bf40bc8105f529700b">+8/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>010_import.tf</strong><dd><code>Add test configuration for importing `lightdash_group`</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal/provider/acc_tests/resource_lightdash_group/import/010_import.tf

<li>Adds a test configuration file for importing a <code>lightdash_group</code> <br>resource.<br> <li> Defines a <code>lightdash_group</code> resource named <code>test_group</code> with a specified <br><code>organization_uuid</code>, <code>name</code>, and empty <code>members</code>.


</details>


  </td>
  <td><a href="https://github.com/ubie-oss/terraform-provider-lightdash/pull/268/files#diff-b8ca8b91d631296f8e1e36b9f0ce9849c39a37238ec9eb6f03458d71e54d6bd5">+8/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>