### PR TITLE
Fix ACC test for `data_source_lightdash_organization_members`


### DIFF
--- a/internal/provider/acc_tests/data_source_lightdash_organization_members/data/01_data.tf
+++ b/internal/provider/acc_tests/data_source_lightdash_organization_members/data/01_data.tf
@@ -1,2 +1,2 @@
-data "lightdash_organization" "test" {
+data "lightdash_organization_members" "test" {
 }

--- a/internal/provider/data_source_lightdash_organization_members_test.go
+++ b/internal/provider/data_source_lightdash_organization_members_test.go
@@ -47,12 +47,12 @@ func TestAccOrganizationMembersDataSource(t *testing.T) {
 				Config: providerConfig + config,
 				Check: resource.ComposeTestCheckFunc(
 					// lightdash_project_role_group.resource_lightdash_project_role_group__grant
-					resource.TestCheckResourceAttrSet("data.lightdash_organization.test", "organization_uuid"),
-					resource.TestCheckTypeSetElemNestedAttrs("data.lightdash_organization.test", "members.*", map[string]string{
-						"user_uuid": "user_uuid",
-						"email":     "email",
-						"role":      "role",
-					}),
+					resource.TestCheckResourceAttrSet("data.lightdash_organization_members.test", "organization_uuid"),
+					// TODO: Add check for members
+					//       We need to figure out the expression to specify wildcard for members in the terraform acceptance test
+					resource.TestCheckResourceAttrSet("data.lightdash_organization_members.test", "members.0.user_uuid"),
+					resource.TestCheckResourceAttrSet("data.lightdash_organization_members.test", "members.0.email"),
+					resource.TestCheckResourceAttrSet("data.lightdash_organization_members.test", "members.0.role"),
 				),
 			},
 		},


### PR DESCRIPTION
### **PR Type**
Bug fix, Tests


___

### **Description**
- Fix: Update data source name from `lightdash_organization` to `lightdash_organization_members`.

- Test: Add checks for `user_uuid`, `email`, and `role` attributes within the `members` list.

- Chore: Remove the `TestCheckTypeSetElemNestedAttrs` function.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>data_source_lightdash_organization_members_test.go</strong><dd><code>Refactor test checks for organization members data source</code></dd></summary>
<hr>

internal/provider/data_source_lightdash_organization_members_test.go

<li>Updated resource attribute checks to use <br><code>data.lightdash_organization_members.test</code>.<br> <li> Added checks for <code>members.0.user_uuid</code>, <code>members.0.email</code>, and <br><code>members.0.role</code>.<br> <li> Removed <code>TestCheckTypeSetElemNestedAttrs</code> function.


</details>


  </td>
  <td><a href="https://github.com/ubie-oss/terraform-provider-lightdash/pull/273/files#diff-cc912747b6ae3d9b328d538b3603a71bc5d6ab37c5fad625c44e51d6ddfe8df2">+6/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>01_data.tf</strong><dd><code>Rename data source in acceptance test config</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal/provider/acc_tests/data_source_lightdash_organization_members/data/01_data.tf

<li>Renamed data source from <code>lightdash_organization</code> to <br><code>lightdash_organization_members</code>.


</details>


  </td>
  <td><a href="https://github.com/ubie-oss/terraform-provider-lightdash/pull/273/files#diff-2d9d626426ba1d81edbd34d6c87aabc97107f68d08da73f3872467e1b1ecbbf5">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>