### PR TITLE
Fix API error when updating root space with unchanged `isPrivate`


### DIFF
--- a/internal/lightdash/controllers/space.go
+++ b/internal/lightdash/controllers/space.go
@@ -622,18 +622,19 @@ func (c *SpaceController) updateRootSpace(
 		isPrivateForUpdate = isPrivate
 	}
 
-	// 1. Update the space properties via the service layer
-	updatedSpaceDetails, err := c.spaceService.UpdateRootSpace(ctx, projectUUID, spaceUUID, spaceName, isPrivateForUpdate)
-	if err != nil {
-		return []error{fmt.Errorf("failed to update space properties: %w", err)}
+	// 1. Update the space properties via the service layer if they have changed
+	if spaceName != currentSpaceDetails.SpaceName || isPrivateForUpdate != nil {
+		updatedSpaceDetails, err := c.spaceService.UpdateRootSpace(ctx, projectUUID, spaceUUID, spaceName, isPrivateForUpdate)
+		if err != nil {
+			return []error{fmt.Errorf("failed to update space properties: %w", err)}
+		}
+		tflog.Debug(ctx, "(SpaceController.updateRootSpace) Updated space details", map[string]interface{}{
+			"projectUUID": updatedSpaceDetails.ProjectUUID,
+			"spaceUUID":   updatedSpaceDetails.SpaceUUID,
+			"spaceName":   updatedSpaceDetails.SpaceName,
+			"isPrivate":   updatedSpaceDetails.IsPrivate,
+		})
 	}
-
-	tflog.Debug(ctx, "(SpaceController.updateRootSpace) Updated space details", map[string]interface{}{
-		"projectUUID": updatedSpaceDetails.ProjectUUID,
-		"spaceUUID":   updatedSpaceDetails.SpaceUUID,
-		"spaceName":   updatedSpaceDetails.SpaceName,
-		"isPrivate":   updatedSpaceDetails.IsPrivate,
-	})
 
 	// 2. Manage member access (add/update/remove direct access)
 	memberErrors := c.manageRootSpaceMemberAccess(

--- a/internal/lightdash/controllers/space.go
+++ b/internal/lightdash/controllers/space.go
@@ -615,8 +615,15 @@ func (c *SpaceController) updateRootSpace(
 		"currentSpaceDetails": currentSpaceDetails,
 	})
 
+	// If isPrivate isn't changed, then it is nil.
+	// This is a workaround to avoid the API from returning an error.
+	var isPrivateForUpdate *bool
+	if isPrivate != nil && *isPrivate != currentSpaceDetails.IsPrivate {
+		isPrivateForUpdate = isPrivate
+	}
+
 	// 1. Update the space properties via the service layer
-	updatedSpaceDetails, err := c.spaceService.UpdateRootSpace(ctx, projectUUID, spaceUUID, spaceName, isPrivate)
+	updatedSpaceDetails, err := c.spaceService.UpdateRootSpace(ctx, projectUUID, spaceUUID, spaceName, isPrivateForUpdate)
 	if err != nil {
 		return []error{fmt.Errorf("failed to update space properties: %w", err)}
 	}


### PR DESCRIPTION
## Overview

We encountered an issue that we can't call the API to update a space due to the error `Can't change privacy for a nested space`. though the space we tried to update is a root space not a nested space.

If we don't pass the `isPrivate` parameter, I was able to call the API to update a space. So, this is a workaround not to pass the parameter to the API, if the value of `isPrivate` isn't changed.

By the way, the error message is located at the code. I will delve into the details later.

https://github.com/lightdash/lightdash/blob/4e1b31e92c6e94031a5f624f6f22dac3d047e16e/packages/backend/src/services/SpaceService/SpaceService.ts#L228-L231

```shell
#!/bin/bash

LIGHTDASH_API_KEY="..."
LIGHTDASH_URL="https://..."
PROJECT_UUID="..."
SPACE_UUID="..."

curl -X PATCH \
  "${LIGHTDASH_URL}/api/v1/projects/${PROJECT_UUID}/spaces/${SPACE_UUID}" \
  -H "Authorization: ApiKey ${LIGHTDASH_API_KEY}" \
  -H "Content-Type: application/json" \
  -d '{
  "name": "xxx",
  "isPrivate": false
}'
```

```shell
{"status":"error","error":{"statusCode":403,"name":"ForbiddenError","message":"Can't change privacy for a nested space","data":{}}}
```