### PR TITLE
ci: namespace release Go cache by workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,7 +46,19 @@ jobs:
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: go.mod
-          cache: true
+          cache: false
+
+      # Namespace the release cache by workflow so it cannot share a key with
+      # PR-triggered workflows (test.yml, check-goreleaser.yml) that also build Go.
+      - name: Cache Go build
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        with:
+          path: |
+            ~/.cache/go-build
+            ~/go/pkg/mod
+          key: ${{ runner.os }}-${{ github.workflow }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ github.workflow }}-go-
       - name: Import GPG key
         uses: crazy-max/ghaction-import-gpg@v6
         id: import_gpg


### PR DESCRIPTION
## Summary

`release.yml`, `test.yml`, and `check-goreleaser.yml` all enabled `actions/setup-go`'s built-in cache (`cache: true`), which produces a key from `runner.os` + `go-version-file` + `go.sum` hash only. The three workflows therefore share a cache key.

Replace the built-in cache on `release.yml` with an explicit `actions/cache@v4` whose key is namespaced by `github.workflow`, so the release/goreleaser path never restores a cache produced by a PR-triggered workflow.

## Why

GitHub Actions scopes cache by branch by default, so today this is safe: a PR cannot poison `main`'s cache without `pull_request_target` (this repo does not use that trigger). But if `pull_request_target` is ever introduced, a PR could write to `main`'s cache scope under the shared key and `release.yml` (which runs on tag push and inherits `main`'s cache scope) would restore it. The release job's runtime would then execute attacker-controlled Go module content — bypassing the `environment: release` protection, which only gates secrets, not the runner.

Namespacing the release cache removes this future foot-gun. `test.yml` and `check-goreleaser.yml` are intentionally left as-is for now since they share the same risk profile as each other (both PR-triggered) and gain less from namespacing.

## Notes

`actions/cache@v4` is pinned to the same SHA the `v4` major tag currently resolves to (`0057852b...`), consistent with the SHA-pinning convention already used in this workflow.

## Test plan
- [ ] Cut a tag and verify the release workflow still runs end-to-end (cache will be cold on first run after merge)