### PR TITLE
CI: Namespace Release Go Cache to Prevent Pollution

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,7 +46,19 @@ jobs:
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # ratchet:actions/setup-go@v6.4.0
         with:
           go-version-file: go.mod
-          cache: true
+          cache: false
+
+      # Namespace the release cache by workflow so it cannot share a key with
+      # PR-triggered workflows (test.yml, check-goreleaser.yml) that also build Go.
+      - name: Cache Go build
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # ratchet:actions/cache@v4
+        with:
+          path: |
+            ~/.cache/go-build
+            ~/go/pkg/mod
+          key: ${{ runner.os }}-${{ github.workflow }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ github.workflow }}-go-
       - name: Import GPG key
         uses: crazy-max/ghaction-import-gpg@2dc316deee8e90f13e1a351ab510b4d5bc0c82cd # ratchet:crazy-max/ghaction-import-gpg@v7
         id: import_gpg


### PR DESCRIPTION
### **User description**
## Summary

Supersedes implementation effort for #436 on current `main` (after action ratchet pinning in #439).

- Disable `actions/setup-go` built-in cache on `release.yml`
- Add workflow-namespaced `actions/cache@v4` for Go module/build caches

## Why

`release.yml`, `test.yml`, and `check-goreleaser.yml` all used `setup-go` with `cache: true`, producing the same cache key (`runner.os` + `go-version-file` + `go.sum`). Namespacing the release cache by `${{ github.workflow }}` avoids a future foot-gun if `pull_request_target` were ever introduced (a PR could otherwise pollute caches visible to tag-triggered release runs).

`test.yml` and `check-goreleaser.yml` are intentionally unchanged (same risk profile as each other).

## Related

- Original PR: #436 (left open per maintainer decision)

## Test plan

- [ ] CI passes on this PR (Build, GoReleaser check, Trunk)
- [ ] After merge: cut a tag and confirm release workflow succeeds (first run will have a cold cache)


Made with [Cursor](https://cursor.com)


___

### **PR Type**
Enhancement


___

### **Description**
- Disable `setup-go` built-in cache in `release.yml`.

- Add explicit, workflow-namespaced Go cache for release.

- Prevent cache pollution from other CI/CD workflows.

- Enhance CI/CD security and reliability.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["release.yml workflow"] --> B["actions/setup-go (cache disabled)"]
  B --> C["actions/cache (Go modules/build)"]
  C -- "Cache key includes `github.workflow`" --> D["Isolated Go Cache"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>release.yml</strong><dd><code>Namespace Go cache in release workflow for isolation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/release.yml

<ul><li>Disabled the built-in cache for <code>actions/setup-go</code>.<br> <li> Introduced a new <code>actions/cache</code> step for Go build and module caches.<br> <li> Configured the new cache key to include <code>github.workflow</code> for unique <br>namespacing.<br> <li> Added <code>restore-keys</code> that also incorporate the workflow name.</ul>


</details>


  </td>
  <td><a href="https://github.com/ubie-oss/terraform-provider-lightdash/pull/442/files#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34">+13/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

