### PR TITLE
Bump provider version to 0.15.0.

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ terraform {
   required_providers {
     lightdash = {
       source  = "ubie-oss/lightdash"
-      version = "0.14.4"
+      version = "0.15.0"
     }
   }
 }

--- a/main.go
+++ b/main.go
@@ -36,7 +36,7 @@ import (
 var (
 	// these will be set by the goreleaser configuration
 	// to appropriate values for the compiled binary.
-	version string = "0.14.4"
+	version string = "0.15.0"
 
 	// goreleaser can pass other information to the main package, such as the specific commit
 	// https://goreleaser.com/cookbooks/using-main.version/


### PR DESCRIPTION
Prepare for release with OAuth application resource and data sources.