### PR TITLE
Bump provider version to 0.16.0.

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ terraform {
   required_providers {
     lightdash = {
       source  = "ubie-oss/lightdash"
-      version = "0.15.0"
+      version = "0.16.0"
     }
   }
 }

--- a/main.go
+++ b/main.go
@@ -36,7 +36,7 @@ import (
 var (
 	// these will be set by the goreleaser configuration
 	// to appropriate values for the compiled binary.
-	version string = "0.15.0"
+	version string = "0.16.0"
 
 	// goreleaser can pass other information to the main package, such as the specific commit
 	// https://goreleaser.com/cookbooks/using-main.version/


### PR DESCRIPTION
## Summary

- Bump provider version from 0.15.0 to 0.16.0 in `main.go` and `README.md`.
- Prepares for release after the v2 role IAM migration work in #451 and #452.

## Test plan

- [x] `go build -mod=mod -v ./`


Made with [Cursor](https://cursor.com)